### PR TITLE
build: update zeebe to version 8.1.2, Jdk set to 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           cache: 'maven'
       - name: Build

--- a/exporter/pom.xml
+++ b/exporter/pom.xml
@@ -19,6 +19,17 @@
   </properties>
 
   <dependencies>
+    <!-- serialization -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
     <!-- runtime dependencies which must be packaged with the exporter -->
     <dependency>
       <groupId>io.zeebe</groupId>
@@ -44,6 +55,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-jackson</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <artifactId>slf4j-api</artifactId>
       <groupId>org.slf4j</groupId>
       <scope>provided</scope>
@@ -58,13 +75,7 @@
     <!-- test dependencies -->
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-jackson</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-test</artifactId>
+      <artifactId>zeebe-exporter-test</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/exporter/src/test/java/io/zeebe/exporters/kafka/config/parser/RawRecordsConfigParserTest.java
+++ b/exporter/src/test/java/io/zeebe/exporters/kafka/config/parser/RawRecordsConfigParserTest.java
@@ -31,7 +31,15 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 @Execution(ExecutionMode.CONCURRENT)
 final class RawRecordsConfigParserTest {
   private static final Set<ValueType> EXPECTED_VALUE_TYPES =
-      EnumSet.complementOf(EnumSet.of(ValueType.NULL_VAL, ValueType.SBE_UNKNOWN));
+      EnumSet.complementOf(EnumSet.of(
+        ValueType.NULL_VAL,
+        ValueType.SBE_UNKNOWN,
+        ValueType.DECISION,
+        ValueType.DECISION_REQUIREMENTS,
+        ValueType.DECISION_EVALUATION,
+        ValueType.CHECKPOINT,
+        ValueType.PROCESS_INSTANCE_MODIFICATION
+      ));
 
   private final RawRecordsConfigParser parser = new RawRecordsConfigParser();
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <!-- release parent settings -->
-    <version.java>11</version.java>
+    <version.java>17</version.java>
     <nexus.snapshot.repository>
       https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
     </nexus.snapshot.repository>
@@ -51,8 +51,8 @@
     <version.slf4j>1.7.36</version.slf4j>
     <version.spotbugs>4.2.0</version.spotbugs>
     <version.testcontainers>1.17.4</version.testcontainers>
-    <version.zeebe>1.3.6</version.zeebe>
     <version.zeebe-test-container>3.5.2</version.zeebe-test-container>
+    <version.zeebe>8.1.2</version.zeebe>
 
     <!-- plugin version -->
     <plugin.version.animal-sniffer>1.22</plugin.version.animal-sniffer>
@@ -60,11 +60,10 @@
     <plugin.version.compiler>3.10.1</plugin.version.compiler>
     <plugin.version.checkstyle>3.2.0</plugin.version.checkstyle>
     <plugin.version.clean>3.2.0</plugin.version.clean>
-    <plugin.version.dependency-analyzer>1.11.1</plugin.version.dependency-analyzer>
-    <plugin.version.dependency>3.1.2</plugin.version.dependency>
+    <plugin.version.dependency-analyzer>1.11.2</plugin.version.dependency-analyzer>
+    <plugin.version.dependency>3.3.0</plugin.version.dependency>
     <plugin.version.enforcer>3.1.0</plugin.version.enforcer>
     <plugin.version.failsafe>3.0.0-M7</plugin.version.failsafe>
-    <plugin.version.fmt>2.13</plugin.version.fmt>
     <plugin.version.gpg>3.0.1</plugin.version.gpg>
     <plugin.version.javadoc>3.4.1</plugin.version.javadoc>
     <plugin.version.license>4.1</plugin.version.license>
@@ -72,6 +71,7 @@
     <plugin.version.proto-compat>1.0.6</plugin.version.proto-compat>
     <plugin.version.revapi>0.14.7</plugin.version.revapi>
     <plugin.version.surefire>3.0.0-M7</plugin.version.surefire>
+    <plugin.version.spotless>2.17.3</plugin.version.spotless>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.6.1</extension.version.os-maven-plugin>
@@ -88,6 +88,7 @@
     <enforcer.skip>${skipChecks}</enforcer.skip>
     <mdep.analyze.skip>${skipChecks}</mdep.analyze.skip>
     <revapi.skip>${skipChecks}</revapi.skip>
+    <spotless.apply.skip>${skipChecks}</spotless.apply.skip>
     <spotless.check.skip>${skipChecks}</spotless.check.skip>
   </properties>
 
@@ -115,6 +116,24 @@
         <type>pom</type>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-protocol-jackson</artifactId>
+        <version>${version.zeebe}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-protocol-asserts</artifactId>
+        <version>${version.zeebe}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-exporter-test</artifactId>
+        <version>${version.zeebe}</version>
+      </dependency>
+
       <!-- Integration testing via Docker -->
       <dependency>
         <groupId>org.testcontainers</groupId>
@@ -128,6 +147,12 @@
         <groupId>io.zeebe</groupId>
         <artifactId>zeebe-test-container</artifactId>
         <version>${version.zeebe-test-container}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>zeebe-process-test-extension</artifactId>
+        <version>${version.zeebe}</version>
       </dependency>
 
       <!-- Unit test engine -->
@@ -351,16 +376,17 @@
 
         <!-- Google code format plugin -->
         <plugin>
-          <groupId>com.coveo</groupId>
-          <artifactId>fmt-maven-plugin</artifactId>
-          <version>${plugin.version.fmt}</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>format</goal>
-              </goals>
-            </execution>
-          </executions>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>${plugin.version.spotless}</version>
+          <configuration>
+            <java>
+              <googleJavaFormat>
+                <version>1.12.0</version>
+                <style>GOOGLE</style>
+              </googleJavaFormat>
+            </java>
+          </configuration>
         </plugin>
 
         <!-- jar with dependency assembly -->
@@ -403,13 +429,6 @@
           <artifactId>maven-dependency-plugin</artifactId>
           <version>${plugin.version.dependency}</version>
           <!-- To run with Java 11 - https://issues.apache.org/jira/browse/MDEP-613-->
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.maven.shared</groupId>
-              <artifactId>maven-dependency-analyzer</artifactId>
-              <version>${plugin.version.dependency-analyzer}</version>
-            </dependency>
-          </dependencies>
 
           <executions>
             <execution>
@@ -495,11 +514,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
       </plugin>
 
       <plugin>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -30,12 +30,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-jackson</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <scope>test</scope>

--- a/qa/src/test/java/io/zeebe/exporters/kafka/qa/DebugHttpExporterClient.java
+++ b/qa/src/test/java/io/zeebe/exporters/kafka/qa/DebugHttpExporterClient.java
@@ -18,7 +18,6 @@ package io.zeebe.exporters.kafka.qa;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import io.camunda.zeebe.protocol.jackson.record.AbstractRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -42,7 +41,7 @@ import java.util.stream.Stream;
 final class DebugHttpExporterClient {
 
   private static final ObjectReader READER =
-      new ObjectMapper().readerFor(new TypeReference<List<AbstractRecord<?>>>() {});
+      new ObjectMapper().readerFor(new TypeReference<List<Record<?>>>() {});
 
   private final URL serverUrl;
 
@@ -53,7 +52,7 @@ final class DebugHttpExporterClient {
   Stream<Record<?>> streamRecords() {
     try {
       // the HTTP exporter returns records in reversed order, so flip them before returning
-      final List<AbstractRecord<?>> records = READER.readValue(serverUrl);
+      final List<Record<?>> records = READER.readValue(serverUrl);
       Collections.reverse(records);
 
       return records.stream().map(r -> r);

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -23,11 +23,6 @@
   <dependencies>
     <!-- serialization -->
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-jackson</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -49,6 +44,11 @@
     </dependency>
 
     <!-- Zeebe -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-jackson</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>

--- a/serde/src/main/java/io/zeebe/exporters/kafka/serde/RecordDeserializer.java
+++ b/serde/src/main/java/io/zeebe/exporters/kafka/serde/RecordDeserializer.java
@@ -18,7 +18,7 @@ package io.zeebe.exporters.kafka.serde;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import io.camunda.zeebe.protocol.jackson.record.AbstractRecord;
+import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import org.apache.kafka.common.serialization.Deserializer;
 
@@ -31,11 +31,11 @@ import org.apache.kafka.common.serialization.Deserializer;
 public final class RecordDeserializer extends JacksonDeserializer<Record<?>> {
 
   public RecordDeserializer() {
-    this(new ObjectMapper());
+    this(new ObjectMapper().registerModule(new ZeebeProtocolModule()));
   }
 
   public RecordDeserializer(final ObjectMapper objectMapper) {
-    this(objectMapper.readerFor(new TypeReference<AbstractRecord<?>>() {}));
+    this(objectMapper.registerModule(new ZeebeProtocolModule()).readerFor(new TypeReference<Record<?>>() {}));
   }
 
   public RecordDeserializer(final ObjectReader objectReader) {

--- a/serde/src/main/java/io/zeebe/exporters/kafka/serde/RecordSerializer.java
+++ b/serde/src/main/java/io/zeebe/exporters/kafka/serde/RecordSerializer.java
@@ -18,7 +18,7 @@ package io.zeebe.exporters.kafka.serde;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import io.camunda.zeebe.protocol.jackson.record.AbstractRecord;
+import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import org.apache.kafka.common.serialization.Serializer;
 
@@ -34,11 +34,11 @@ import org.apache.kafka.common.serialization.Serializer;
  */
 public final class RecordSerializer extends JacksonSerializer<Record<?>> {
   public RecordSerializer() {
-    this(new ObjectMapper());
+    this(new ObjectMapper().registerModule(new ZeebeProtocolModule()));
   }
 
   protected RecordSerializer(final ObjectMapper objectMapper) {
-    this(objectMapper.writerFor(new TypeReference<AbstractRecord<?>>() {}));
+    this(objectMapper.registerModule(new ZeebeProtocolModule()).writerFor(new TypeReference<Record<?>>() {}));
   }
 
   protected RecordSerializer(final ObjectWriter writer) {

--- a/serde/src/test/java/io/zeebe/exporters/kafka/serde/RecordTest.java
+++ b/serde/src/test/java/io/zeebe/exporters/kafka/serde/RecordTest.java
@@ -19,13 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
-import io.camunda.zeebe.protocol.jackson.record.DeploymentRecordValueBuilder;
-import io.camunda.zeebe.protocol.jackson.record.RecordBuilder;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
-import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDeploymentRecordValue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -37,13 +36,15 @@ final class RecordTest {
   @Test
   void shouldSerialize() {
     // given
+    ImmutableDeploymentRecordValue.builder().build();
     final Record<?> record =
-        new RecordBuilder<DeploymentRecordValue>()
-            .intent(DeploymentIntent.CREATED)
-            .recordType(RecordType.EVENT)
-            .valueType(ValueType.DEPLOYMENT)
-            .value(new DeploymentRecordValueBuilder().build())
-            .build();
+        ImmutableRecord.builder()
+          .withIntent(DeploymentIntent.CREATED)
+          .withRecordType(RecordType.EVENT)
+          .withValueType(ValueType.DEPLOYMENT)
+          .withValue(ImmutableDeploymentRecordValue.builder().build())
+          .build();
+
     final RecordSerializer serializer = new RecordSerializer();
     final RecordDeserializer deserializer = new RecordDeserializer();
 
@@ -62,12 +63,12 @@ final class RecordTest {
     // given
     final ObjectMapper cborMapper = new CBORMapper();
     final Record<?> record =
-        new RecordBuilder<DeploymentRecordValue>()
-            .intent(DeploymentIntent.CREATED)
-            .recordType(RecordType.EVENT)
-            .valueType(ValueType.DEPLOYMENT)
-            .value(new DeploymentRecordValueBuilder().build())
-            .build();
+      ImmutableRecord.builder()
+        .withIntent(DeploymentIntent.CREATED)
+        .withRecordType(RecordType.EVENT)
+        .withValueType(ValueType.DEPLOYMENT)
+        .withValue(ImmutableDeploymentRecordValue.builder().build())
+        .build();
     final RecordSerializer serializer = new RecordSerializer(cborMapper);
     final RecordDeserializer deserializer = new RecordDeserializer(cborMapper);
 


### PR DESCRIPTION
## Description

Java set to 17 to use camunda libs
Upgrade camunda to vesionn 8.1.2 !
Replace fmt by spotless

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

## Pull Request Checklist

- [ ] All commit messages match our [commit message guidelines](https://github.com/zeebe-io/zeebe/blob/develop/CONTRIBUTING.md#commit-message-guidelines)
- [ ] The submitting code follows our [code style](https://github.com/zeebe-io/zeebe/wiki/Code-Style)
- [x] If submitting code, please run `mvn clean install -DskipTests` locally before committing
- [ ] Ensure all PR checks are green